### PR TITLE
Switch to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+  - "/.*-[0-9]+\\..*/"
+install: true
+script: ".travis/build.sh"
+cache:
+  directories:
+  - "~/.m2/repository"

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
+sh travis-build.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://travis-ci.org/odinsbane/jfilament.svg?branch=master)](https://travis-ci.org/odinsbane/jfilament)
+
 # jfilament
 JFilament is an ImageJ plugin for segmentation and tracking of 2D and 3D filaments in fluorescenece microscopy images. The main algorithm used in Jfilament is "Stretching Open Active Contours".
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>21.4.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>20.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -16,6 +16,10 @@
 	<description>JFilament, 2D and 3D active contours.</description>
 	<url>http://athena.physics.lehigh.edu/jfilament</url>
 	<inceptionYear>2010</inceptionYear>
+	<organization>
+		<name>UCL LMCB</name>
+		<url>http://ucl.ac.uk/lmcb</url>
+	</organization>
 	<licenses>
 		<license>
 			<name>Modified BSD License</name>
@@ -43,6 +47,20 @@
 			<timezone>+1</timezone>
 		</developer>
 	</developers>
+	<contributors>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
 
 	<scm>
 		<connection>scm:git:git://github.com/odinsbane/jfilament</connection>
@@ -59,8 +77,12 @@
 		<url>http://jenkins.imagej.net/job/JFilament/</url>
 	</ciManagement>
 
+	<properties>
+		<license.licenseName>bsd_3</license.licenseName>
+		<license.copyrightOwners>University College London</license.copyrightOwners>
+	</properties>
+
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>
@@ -101,7 +123,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -115,7 +136,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.3</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>sc.fiji</groupId>
@@ -13,58 +10,58 @@
 
 	<artifactId>JFilament_</artifactId>
 	<version>1.1.4-SNAPSHOT</version>
-    <name>JFilament</name>
+	<name>JFilament</name>
 	<description>JFilament, 2D and 3D active contours.</description>
-    <url>http://athena.physics.lehigh.edu/jfilament</url>
-    <inceptionYear>2010</inceptionYear>
-    <licenses>
-        <license>
-            <name>Modified BSD License</name>
-            <url>https://opensource.org/licenses/BSD-3-Clause</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <id>odinsbane</id>
-            <name>Matthew Smith</name>
-            <email>MattTheBruce@gmail.com</email>
-            <url>https://orangepalantir.org</url>
-            <organization>UCL LMCB</organization>
-            <organizationUrl>http://ucl.ac.uk/lmcb</organizationUrl>
-            <roles>
-                <role>lead</role>
-                <role>developer</role>
-                <role>debugger</role>
-                <role>reviewer</role>
-                <role>support</role>
-                <role>maintainer</role>
-            </roles>
-            <timezone>+1</timezone>
-        </developer>
-    </developers>
+	<url>http://athena.physics.lehigh.edu/jfilament</url>
+	<inceptionYear>2010</inceptionYear>
+	<licenses>
+		<license>
+			<name>Modified BSD License</name>
+			<url>https://opensource.org/licenses/BSD-3-Clause</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<id>odinsbane</id>
+			<name>Matthew Smith</name>
+			<email>MattTheBruce@gmail.com</email>
+			<url>https://orangepalantir.org</url>
+			<organization>UCL LMCB</organization>
+			<organizationUrl>http://ucl.ac.uk/lmcb</organizationUrl>
+			<roles>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+	</developers>
 
-    <issueManagement>
-        <system>GitHub Issues</system>
-        <url>https://github.com/odinsbane/jfilament/issues</url>
-    </issueManagement>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/odinsbane/jfilament/issues</url>
+	</issueManagement>
 	<ciManagement>
 		<system>Jenkins</system>
 		<url>http://jenkins.imagej.net/job/JFilament/</url>
 	</ciManagement>
-    <scm>
+	<scm>
 		<connection>scm:git:git://github.com/odinsbane/jfilament</connection>
 		<developerConnection>scm:git:git@github.com:odinsbane/jfilament</developerConnection>
 		<tag>HEAD</tag>
 		<url>https://github.com/odinsbane/jfilament</url>
 	</scm>
-    <repositories>
-        <!-- NB: for project parent -->
-        <repository>
-            <id>imagej.public</id>
-            <url>http://maven.imagej.net/content/groups/public</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<!-- NB: for project parent -->
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -72,9 +69,9 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>net.imagej</groupId>
-            <artifactId>ij</artifactId>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>gov.nist.math</groupId>
@@ -88,12 +85,12 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>vecmath</artifactId>
 		</dependency>
-        <dependency>
+		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>j3dutils</artifactId>
 		</dependency>
 	</dependencies>
-    <build>
+	<build>
 		<plugins>
 			<!-- Generates a source code JAR during package -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,16 @@
 		<url>https://github.com/odinsbane/jfilament/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/JFilament/</url>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/odinsbane/jfilament</url>
 	</ciManagement>
 
 	<properties>
 		<license.licenseName>bsd_3</license.licenseName>
 		<license.copyrightOwners>University College London</license.copyrightOwners>
+
+		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
+		<releaseProfiles>deploy-to-imagej</releaseProfiles>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<relativePath />
 		<version>21.4.0</version>
+		<relativePath />
 	</parent>
 
 	<artifactId>JFilament_</artifactId>
 	<version>1.1.4-SNAPSHOT</version>
+
 	<name>JFilament</name>
 	<description>JFilament, 2D and 3D active contours.</description>
 	<url>http://athena.physics.lehigh.edu/jfilament</url>
@@ -21,6 +23,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
+
 	<developers>
 		<developer>
 			<id>odinsbane</id>
@@ -41,6 +44,12 @@
 		</developer>
 	</developers>
 
+	<scm>
+		<connection>scm:git:git://github.com/odinsbane/jfilament</connection>
+		<developerConnection>scm:git:git@github.com:odinsbane/jfilament</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/odinsbane/jfilament</url>
+	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
 		<url>https://github.com/odinsbane/jfilament/issues</url>
@@ -49,12 +58,7 @@
 		<system>Jenkins</system>
 		<url>http://jenkins.imagej.net/job/JFilament/</url>
 	</ciManagement>
-	<scm>
-		<connection>scm:git:git://github.com/odinsbane/jfilament</connection>
-		<developerConnection>scm:git:git@github.com:odinsbane/jfilament</developerConnection>
-		<tag>HEAD</tag>
-		<url>https://github.com/odinsbane/jfilament</url>
-	</scm>
+
 	<repositories>
 		<!-- NB: for project parent -->
 		<repository>
@@ -90,6 +94,7 @@
 			<artifactId>j3dutils</artifactId>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
 			<!-- Generates a source code JAR during package -->
@@ -126,6 +131,3 @@
 		</plugins>
 	</build>
 </project>
-
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	</parent>
 
 	<artifactId>JFilament_</artifactId>
-	<version>1.1.3</version>
+	<version>1.1.4-SNAPSHOT</version>
     <name>JFilament</name>
 	<description>JFilament, 2D and 3D active contours.</description>
     <url>http://athena.physics.lehigh.edu/jfilament</url>


### PR DESCRIPTION
The [ImageJ Jenkins](https://jenkins.imagej.net/) is in the process of being decommissioned. The JFilament project is [still hooked up to it](https://jenkins.imagej.net/job/JFilament/). The migration path for components in the Fiji software stack has been to switch to Travis CI. This PR updates this repository to build and deploy using Travis CI rather than the ImageJ Jenkins.

You will need to visit https://travis-ci.org/profile and authorize it, then enable the odinsbane/jfilament repository, for the CI builds to start happening. I also advise visiting https://travis-ci.org/odinsbane/jfilament/settings next, and switching ON the options "Build only if .travis.yml is present" and "Build pushed branches" and "Build pushed pull requests".

This update will also enable you to release new versions of `JFilament` using the `release-version.sh` script in [scijava-scripts](https://github.com/scijava/scijava-scripts), once the ImageJ Maven repository's (encrypted) deployment credentials are added. I cannot add those credentials until Travis CI is enabled for this repository as described above, however.